### PR TITLE
Provide granular support data for each support stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,31 @@ script/server
 
 The data is available at the following routes:
 
-### Support rota
+### Support rota (dev and ops eng)
 
 - http://localhost:3000/support/rota.ics
 - http://localhost:3000/support/rota.json
 
-### Out of hours
+### Out of hours (1st and 2nd lines)
 
 - http://localhost:3000/out-of-hours/rota.ics
 - http://localhost:3000/out-of-hours/rota.json
+
+### Developer
+
+- http://localhost:3000/v2/dev/rota.json
+
+### Ops engineer
+
+- http://localhost:3000/v2/ops/rota.json
+
+### OOH First line
+
+- http://localhost:3000/v2/ooh1/rota.json
+
+### OOH Second line
+
+- http://localhost:3000/v2/ooh2/rota.json
 
 ## Running the tests
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ The data is available at the following routes:
 
 ### Support rota
 
-- http://localhost:9292/support/rota.ics
-- http://localhost:9292/support/rota.json
+- http://localhost:3000/support/rota.ics
+- http://localhost:3000/support/rota.json
 
 ### Out of hours
 
-- http://localhost:9292/out-of-hours/rota.ics
-- http://localhost:9292/out-of-hours/rota.json
+- http://localhost:3000/out-of-hours/rota.ics
+- http://localhost:3000/out-of-hours/rota.json
 
 ## Running the tests
 

--- a/app/controllers/v2/rota_controller.rb
+++ b/app/controllers/v2/rota_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class V2::RotaController < ApplicationController
+  def show
+    respond_to do |format|
+      format.json { render json: Patterdale::Json.new(rota).results }
+    end
+  end
+
+  private
+
+  def rota
+    Rails.cache.fetch request.path, expires_in: 12.hours do
+      OpsgenieTamer::SupportRotationsFetcher.new.call(rotation_type: params[:type])
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,7 @@ require "rails/test_unit/railtie"
 Bundler.require(*Rails.groups)
 
 require "./lib/patterdale"
+require "./lib/opsgenie_tamer"
 
 # TODO: Name the application
 module RailsTemplate

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,6 +14,8 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
+  config.action_controller.perform_caching = false
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,10 @@ Rails.application.routes.draw do
 
   get "/feed.ics", to: redirect("/support/rota.ics")
   get "/local-feed.ics", to: redirect("/support/rota.ics")
+
+  namespace :v2 do
+    scope path: ":type", constraints: {type: %r{dev|ops|ooh1|ooh2}} do
+      get "rota", to: "rota#show"
+    end
+  end
 end

--- a/lib/opsgenie_tamer.rb
+++ b/lib/opsgenie_tamer.rb
@@ -1,0 +1,2 @@
+require_relative "opsgenie_tamer/rota"
+require_relative "opsgenie_tamer/support_rotations_fetcher"

--- a/lib/opsgenie_tamer/rota.rb
+++ b/lib/opsgenie_tamer/rota.rb
@@ -1,0 +1,36 @@
+module OpsgenieTamer
+  class Rota
+    attr_reader :date, :role, :person
+
+    def initialize(date:, role:, person:)
+      @date = date.to_date
+      @role = role
+      @person = user_detail(person)
+    end
+
+    def ==(other_rota)
+      date == other_rota.date &&
+        role == other_rota.role &&
+        person == other_rota.person
+    end
+
+    def to_h
+      {
+        date: date,
+        role: role,
+        person: person
+      }
+    end
+
+    private
+
+    def user_detail(user)
+      return nil if user.nil?
+
+      {
+        name: user.full_name,
+        email: user.username
+      }
+    end
+  end
+end

--- a/lib/opsgenie_tamer/support_rotations_fetcher.rb
+++ b/lib/opsgenie_tamer/support_rotations_fetcher.rb
@@ -1,0 +1,57 @@
+module OpsgenieTamer
+  class SupportRotationsFetcher
+    FIRST_LINE_SCHEDULE_ID = "e71d500f-896a-4b28-8b08-3bfe56e1ed76"
+    SECOND_LINE_SCHEDULE_ID = "b8e97704-0e9d-41b5-b27c-9d9027c83943"
+    HISTORICAL_INTERVAL_IN_MONTHS = 2
+    TOTAL_INTERVAL_IN_MONTHS = 12
+
+    def call(rotation_type:)
+      sorted_periods_for_type(rotation_type).map do |period|
+        OpsgenieTamer::Rota.new(
+          date: period.start_date,
+          role: rotation_type,
+          person: period.user
+        )
+      end
+    end
+
+    private
+
+    # attempt to contain the messiness of our OpsGenie schedules and names in one place
+    def timeline_name_regex(rotation_type)
+      return Regexp.new("Rota") if rotation_type == "ooh2"
+      return Regexp.new("ooh", Regexp::IGNORECASE) if rotation_type == "ooh1"
+
+      Regexp.new(rotation_type, Regexp::IGNORECASE)
+    end
+
+    def sorted_periods_for_type(rotation_type)
+      timelines.select { |t| t.name.match?(timeline_name_regex(rotation_type)) }
+        .collect(&:periods)
+        .flatten
+        .sort_by(&:start_date)
+    end
+
+    def timelines
+      @timelines ||= schedules.map { |schedule|
+        schedule.timeline(
+          date: Date.today << HISTORICAL_INTERVAL_IN_MONTHS,
+          interval: TOTAL_INTERVAL_IN_MONTHS,
+          interval_unit: :months
+        )
+      }.flatten
+    end
+
+    def schedules
+      [first_line_schedule, second_line_schedule].compact
+    end
+
+    def first_line_schedule
+      @first_line_schedule ||= Opsgenie::Schedule.find_by_id(FIRST_LINE_SCHEDULE_ID)
+    end
+
+    def second_line_schedule
+      @second_line_schedule ||= Opsgenie::Schedule.find_by_id(SECOND_LINE_SCHEDULE_ID)
+    end
+  end
+end

--- a/spec/features/v2_rota_spec.rb
+++ b/spec/features/v2_rota_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+feature "Rotas" do
+  before do
+    stub_schedule_for_id(OpsgenieTamer::SupportRotationsFetcher::FIRST_LINE_SCHEDULE_ID)
+    stub_schedule_for_id(OpsgenieTamer::SupportRotationsFetcher::SECOND_LINE_SCHEDULE_ID)
+    stub_support_rotations(id: OpsgenieTamer::SupportRotationsFetcher::FIRST_LINE_SCHEDULE_ID)
+    stub_support_rotations(id: OpsgenieTamer::SupportRotationsFetcher::SECOND_LINE_SCHEDULE_ID)
+    stub_opsgenie_users
+  end
+
+  describe "support rota" do
+    scenario "Get a JSON version of the rota" do
+      visit "/v2/dev/rota.json"
+
+      expect(page.response_headers["Content-Type"]).to match(/application\/json/)
+    end
+  end
+end

--- a/spec/opsgenie_tamer/rota_spec.rb
+++ b/spec/opsgenie_tamer/rota_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe OpsgenieTamer::Rota do
+  let(:person) { double(full_name: "Geoff", username: "geoff@tubechallenge.org") }
+  let(:rota) { OpsgenieTamer::Rota.new(date: Time.new(2020, 8, 8, 13, 45, 20), role: "dev", person: person) }
+
+  describe "#==" do
+    it "is true for two objects with the same date, role, and person details" do
+      other_rota = OpsgenieTamer::Rota.new(date: Time.new(2020, 8, 8, 13, 45, 20), role: "dev", person: person)
+
+      expect(other_rota).to eq(rota)
+    end
+
+    it "is false for two objects with at least one different attribute" do
+      other_rota = OpsgenieTamer::Rota.new(date: Time.new(2020, 8, 9, 13, 45, 20), role: "dev", person: person)
+
+      expect(other_rota).not_to eq(rota)
+    end
+  end
+
+  describe "#to_h" do
+    it "returns a hash representation of the rota" do
+      expect(rota.to_h).to eql(date: Date.new(2020, 8, 8), role: "dev", person: {name: "Geoff", email: "geoff@tubechallenge.org"})
+    end
+  end
+end

--- a/spec/opsgenie_tamer/support_rotations_fetcher_spec.rb
+++ b/spec/opsgenie_tamer/support_rotations_fetcher_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe OpsgenieTamer::SupportRotationsFetcher do
+  before do
+    stub_schedule_for_id(OpsgenieTamer::SupportRotationsFetcher::FIRST_LINE_SCHEDULE_ID)
+    stub_schedule_for_id(OpsgenieTamer::SupportRotationsFetcher::SECOND_LINE_SCHEDULE_ID)
+    stub_support_rotations(id: OpsgenieTamer::SupportRotationsFetcher::FIRST_LINE_SCHEDULE_ID)
+    stub_support_rotations(id: OpsgenieTamer::SupportRotationsFetcher::SECOND_LINE_SCHEDULE_ID)
+    stub_opsgenie_users
+  end
+
+  describe "#call" do
+    let(:fetcher) { OpsgenieTamer::SupportRotationsFetcher.new }
+    let(:user) { build(:user, full_name: "Alice", username: "alice@example.com") }
+    let(:rota) { OpsgenieTamer::Rota.new(date: Date.new(2020, 2, 5), role: "dev", person: user) }
+
+    it "returns an array of rotas sorted by date" do
+      rotas = fetcher.call(rotation_type: "dev")
+
+      expect(rotas.first).to eq(rota)
+    end
+  end
+end

--- a/spec/requests/v2/rota_spec.rb
+++ b/spec/requests/v2/rota_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "Rota", type: :request do
+  before do
+    stub_schedule_for_id(OpsgenieTamer::SupportRotationsFetcher::FIRST_LINE_SCHEDULE_ID)
+    stub_schedule_for_id(OpsgenieTamer::SupportRotationsFetcher::SECOND_LINE_SCHEDULE_ID)
+    stub_support_rotations(id: OpsgenieTamer::SupportRotationsFetcher::FIRST_LINE_SCHEDULE_ID)
+    stub_support_rotations(id: OpsgenieTamer::SupportRotationsFetcher::SECOND_LINE_SCHEDULE_ID)
+    stub_opsgenie_users
+  end
+
+  context "for JSON requests" do
+    let(:headers) { json_headers }
+
+    it "returns ok for supported type parameters" do
+      %w[dev ooh1 ooh2 ops].each do |type|
+        get "/v2/#{type}/rota", headers: headers
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  it "returns a routing error for unsupported type parameters" do
+    expect { get "/v2/bla/rota", headers: json_headers }.to raise_error(ActionController::RoutingError)
+  end
+
+  def json_headers
+    {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
+  end
+end

--- a/spec/support/opsgenie_stubs.rb
+++ b/spec/support/opsgenie_stubs.rb
@@ -13,7 +13,7 @@ module OpsgenieStubs
   end
 
   def stub_support_rotations(date: Date.today, id: Patterdale::Support::Rotations::OPSGENIE_SCHEDULE_ID, fixture_name: "support_rotations")
-    url = "https://api.opsgenie.com/v2/schedules/#{id}/timeline?date=#{date}T00:00:00%2B00:00&interval=3&intervalUnit=months"
+    url = %r{https://api.opsgenie.com/v2/schedules/#{id}/timeline\?date=[0-9:%2BT\-]+&interval=\d+&intervalUnit=months}
     body = JSON.parse(File.read(File.join("spec", "fixtures", "#{fixture_name}.json"))).to_json
     stub_request(:get, url)
       .to_return(


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

Adds v2 of support rota API:
- Separate JSON endpoints for each type of support (dev, ops, out of hours first and second line, respectively)
- Does not support iCal requests: the calendar view is only useful as an aggregate of people on in-hours first line support, which v1 continues to provide.

## Next steps
- Better test coverage: feature or request specs?