### PR TITLE
Add 2021 in hours rota to support rota

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,4 @@ ROLLBAR_ENV=development
 DATABASE_URL=postgres://postgres@localhost:5432/support-rota-development
 OPSGENIE_API_KEY=dsadasda
 REDIS_URL=redis://redis:6379/0/cache
+OPSGENIE_IN_HOURS_ROTATION_IDS=b073c102-ecd5-4a6f-acf2-443280074c33,06af48dc-0496-43ea-bae7-77b96e77ff76,3d9295c6-748d-4bd4-a153-8fd559be0722

--- a/.env.test
+++ b/.env.test
@@ -8,3 +8,4 @@
 DATABASE_URL=postgres://postgres@localhost:5432/support-rota-test
 OPSGENIE_API_KEY=someapikey
 REDIS_URL=redis://redis:6379/1/cache
+OPSGENIE_IN_HOURS_ROTATION_IDS=b073c102-ecd5-4a6f-acf2-443280074c33,06af48dc-0496-43ea-bae7-77b96e77ff76,3d9295c6-748d-4bd4-a153-8fd559be0722

--- a/lib/patterdale/support/rotations.rb
+++ b/lib/patterdale/support/rotations.rb
@@ -2,11 +2,10 @@ module Patterdale
   module Support
     class Rotations
       OPSGENIE_SCHEDULE_ID = "e71d500f-896a-4b28-8b08-3bfe56e1ed76"
-      OPSGENIE_IN_HOURS_ROTATION_IDS = [
-        "b073c102-ecd5-4a6f-acf2-443280074c33",
-        "3d9295c6-748d-4bd4-a153-8fd559be0722",
-        "06af48dc-0496-43ea-bae7-77b96e77ff76"
-      ].freeze
+
+      def initialize(in_hours_rotation_ids: ENV.fetch("OPSGENIE_IN_HOURS_ROTATION_IDS"))
+        @in_hours_rotation_ids = in_hours_rotation_ids.split(",")
+      end
 
       def self.create_rota_item(support_batch)
         return unless support_batch.first && support_batch.last
@@ -58,7 +57,7 @@ module Patterdale
       end
 
       def devops_timelines
-        timelines.select { |t| OPSGENIE_IN_HOURS_ROTATION_IDS.include?(t.id) }
+        timelines.select { |t| @in_hours_rotation_ids.include?(t.id) }
       end
 
       private


### PR DESCRIPTION
Removed a defunct in-hours rotation ID from the `OPSGENIE_IN_HOURS_ROTATION_IDS` list.
Then the rotation ID for the 2021 in-hours rotation schedule was then added to ensure that the first 6 months of rotation data is present.
